### PR TITLE
chore: secure env vars

### DIFF
--- a/README_DEPLOY.md
+++ b/README_DEPLOY.md
@@ -26,6 +26,7 @@ Define en **AppVeyor → Settings → Environment** (ocultas/secure):
 - `VITE_BTC_API`, `VITE_DAG_NODE`
 
 *(Para uso local: `web/.env` con los mismos nombres — no subirlo a Git)*
+*El `appveyor.yml` solo contiene `secure: REPLACE_IN_APPVEYOR_UI`; debes ingresar los valores reales en la UI de AppVeyor.*
 
 ## 3) Build local (prueba rápida)
 ```bash

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,12 +10,16 @@ environment:
     secure: REPLACE_IN_APPVEYOR_UI
   VITE_POLYGON_RPC:
     secure: REPLACE_IN_APPVEYOR_UI
-  VITE_BNB_RPC: https://bsc-dataseed1.binance.org
+  VITE_BNB_RPC:
+    secure: REPLACE_IN_APPVEYOR_UI
   VITE_COSMOS_RPC:
     secure: REPLACE_IN_APPVEYOR_UI
-  VITE_COSMOS_DENOM: uatom
-  VITE_BTC_API: https://mempool.space/api
-  VITE_DAG_NODE: https://api.constellationnetwork.io
+  VITE_COSMOS_DENOM:
+    secure: REPLACE_IN_APPVEYOR_UI
+  VITE_BTC_API:
+    secure: REPLACE_IN_APPVEYOR_UI
+  VITE_DAG_NODE:
+    secure: REPLACE_IN_APPVEYOR_UI
 
 init:
   - ps: |


### PR DESCRIPTION
## Summary
- mark BNB, BTC, DAG, and Cosmos denom env vars as secure in `appveyor.yml`
- document that AppVeyor env vars are provided via secure UI values

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a1a6cd17908333b1d2a27ff2fa0c1e