### PR TITLE
Fix AppVeyor auth token syntax

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,7 +69,7 @@ deploy:
   release: v$(APPVEYOR_BUILD_VERSION)
   description: "QuantumCore auto-build (Windows, macOS, Linux)"
   auth_token:
-    secure: %GITHUB_TOKEN%
+    secure: "%GITHUB_TOKEN%"
   draft: false
   prerelease: false
   on:


### PR DESCRIPTION
## Summary
- Quote `%GITHUB_TOKEN%` in AppVeyor auth token to prevent YAML parsing errors

## Testing
- `pip install pyyaml` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a55d8411fc8333a795196131e933eb